### PR TITLE
Update navigation.html.twig

### DIFF
--- a/templates/partials/navigation.html.twig
+++ b/templates/partials/navigation.html.twig
@@ -12,7 +12,7 @@
             <ul class="navbar-nav">
                 {% for page in pages.children.visible %}
                     {% set current_page = (page.active or page.activeChild) ? 'active' : '' %}
-                    {% if config.themes.bootstrap4.dropdown.enabled and page.children.visible.count > 0 %}
+                    {% if theme.dropdown.enabled and page.children.visible.count > 0 %}
                         <li class="nav-item dropdown {{ current_page }}">
                             <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{{ page.menu }}</a>
                             <div class="dropdown-menu">


### PR DESCRIPTION
changing theme variable unbreaks issues with inheritance and with dropdown menus when using modular pages with "onpage_menu: false" in the frontmatter.